### PR TITLE
Install pre-requisite packages as part of pip setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv/
+.idea/
+**egg-info/

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,6 @@ Create pgp keys, encrypt and decrypt messages, sign messages and verify messages
 
 Perfect for the novice to begin secure communication online.
 
-
 **Example of GUI:**
 
 ![example gui image](assets/example.png)
@@ -18,13 +17,14 @@ Perfect for the novice to begin secure communication online.
 ## Usage - if you don't have python or don't even know what that is.
 
 > ### Windows
-> Just click [here](https://drive.google.com/u/0/uc?id=1s_dl9kKAeAH3qqE243vIbR3dvXY8ORYw&export=download) and run. It's a hefty file like this... but it is what it is.
-> 
+> Just click [here](https://drive.google.com/u/0/uc?id=1s_dl9kKAeAH3qqE243vIbR3dvXY8ORYw&export=download) and run. It's
+> a hefty file like this... but it is what it is.
+>
 > ### Linux
 > Come on what are you playing at ... read below.
-> 
+>
 > ### Mac
-> Literally no idea if it works, but I believe just follow the instructions below. 
+> Literally no idea if it works, but I believe just follow the instructions below.
 
 ## Installation - if you have python installed.
 
@@ -36,16 +36,16 @@ pip install pypgpeed
 
 or
 
-```python
+```shell
 git clone https://github.com/lewis-morris/pypgpeed
 cd pypgpeed
-pip install - e.
+pip install -e .
 ```
 
 ## Running
 
 > ### Linux & Windows
-> 
+>
 > Once installed you should be able to run in the console. `pypgpeed`
 >
 > If this does not work you can run with `python -c "from pypgpeed import run_gui; run_gui()"`
@@ -60,6 +60,6 @@ generate the PGP keys you will need.
 
 If you already have a set of keys, you can either enter the plaintext into the relevant boxes where needed, or autoload
 them by choosing their containing directory with `file >> Set Key Location`, please beware that they must be
-called `pri_key.key` and `pub_key.key`  
+called `pri_key.key` and `pub_key.key`
 
 The rest is self explanatory...

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     entry_points = {
         'console_scripts': ['pypgpeed=pypgpeed.run:run'],
     },
+    install_requires=["PyQt6", "PGPy", "qt_material", "pyperclip"],
     url='https://github.com/lewis-morris/pypgped',
     license='mit',
     author='Lewis Morris',


### PR DESCRIPTION
You may not need a `requirements.txt` if you are `setup.py` for managing dependencies. Also added a .gitignore and minor formatting in the README.md file.